### PR TITLE
Renamed incorrect imported pkg, .../virtual-disks to .../virtual_disk… 

### DIFF
--- a/test/multithread_test.go
+++ b/test/multithread_test.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"github.com/vmware/virtual-disks/pkg/disklib"
-	"github.com/vmware/virtual-disks/pkg/virtual-disks"
+	"github.com/vmware/virtual-disks/pkg/virtual_disks"
 	"fmt"
 	"github.com/sirupsen/logrus"
 	"os"
@@ -45,7 +45,7 @@ func TestAligned(t *testing.T) {
 	params := disklib.NewConnectParams("", serverName,thumPrint, userName,
 		password, fcdId, ds, "", "", identity, "", disklib.VIXDISKLIB_FLAG_OPEN_COMPRESSION_SKIPZ,
 		false, disklib.NBD)
-	diskReaderWriter, err := gvddk_high.Open(params, logrus.New())
+	diskReaderWriter, err := virtual_disks.Open(params, logrus.New())
 	if err != nil {
 		disklib.EndAccess(params)
 		t.Errorf("Open failed, got error code: %d, error message: %s.", err.VixErrorCode(), err.Error())
@@ -109,7 +109,7 @@ func TestMiss1(t *testing.T) {
 	params := disklib.NewConnectParams("", serverName,thumPrint, userName,
 		password, fcdId, ds, "", "", identity, "", disklib.VIXDISKLIB_FLAG_OPEN_COMPRESSION_SKIPZ,
 		false, disklib.NBD)
-	diskReaderWriter, err := gvddk_high.Open(params, logrus.New())
+	diskReaderWriter, err := virtual_disks.Open(params, logrus.New())
 	if err != nil {
 		disklib.EndAccess(params)
 		t.Errorf("Open failed, got error code: %d, error message: %s.", err.VixErrorCode(), err.Error())
@@ -173,7 +173,7 @@ func TestMiss2(t *testing.T) {
 	params := disklib.NewConnectParams("", serverName,thumPrint, userName,
 		password, fcdId, ds, "", "", identity, "", disklib.VIXDISKLIB_FLAG_OPEN_COMPRESSION_SKIPZ,
 		false, disklib.NBD)
-	diskReaderWriter, err := gvddk_high.Open(params, logrus.New())
+	diskReaderWriter, err := virtual_disks.Open(params, logrus.New())
 	if err != nil {
 		disklib.EndAccess(params)
 		t.Errorf("Open failed, got error code: %d, error message: %s.", err.VixErrorCode(), err.Error())
@@ -237,7 +237,7 @@ func TestMiss3(t *testing.T) {
 	params := disklib.NewConnectParams("", serverName,thumPrint, userName,
 		password, fcdId, ds, "", "", identity, "", disklib.VIXDISKLIB_FLAG_OPEN_COMPRESSION_SKIPZ,
 		false, disklib.NBD)
-	diskReaderWriter, err := gvddk_high.Open(params, logrus.New())
+	diskReaderWriter, err := virtual_disks.Open(params, logrus.New())
 	if err != nil {
 		disklib.EndAccess(params)
 		t.Errorf("Open failed, got error code: %d, error message: %s.", err.VixErrorCode(), err.Error())
@@ -301,7 +301,7 @@ func TestMissAlign(t *testing.T) {
 	params := disklib.NewConnectParams("", serverName,thumPrint, userName,
 		password, fcdId, ds, "", "", identity, "", disklib.VIXDISKLIB_FLAG_OPEN_COMPRESSION_SKIPZ,
 		false, disklib.NBD)
-	diskReaderWriter, err := gvddk_high.Open(params, logrus.New())
+	diskReaderWriter, err := virtual_disks.Open(params, logrus.New())
 	if err != nil {
 		disklib.EndAccess(params)
 		t.Errorf("Open failed, got error code: %d, error message: %s.", err.VixErrorCode(), err.Error())

--- a/test/open_test.go
+++ b/test/open_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware/virtual-disks/pkg/disklib"
-	"github.com/vmware/virtual-disks/pkg/virtual-disks"
+	"github.com/vmware/virtual-disks/pkg/virtual_disks"
 	"os"
 	"testing"
 )
@@ -44,7 +44,7 @@ func TestOpen(t *testing.T) {
 	params := disklib.NewConnectParams("", serverName,thumPrint, userName,
 		password, fcdId, ds, "", "", identity, "", disklib.VIXDISKLIB_FLAG_OPEN_COMPRESSION_SKIPZ,
 		false, disklib.NBD)
-	diskReaderWriter, err := gvddk_high.Open(params, logrus.New())
+	diskReaderWriter, err := virtual_disks.Open(params, logrus.New())
 	if err != nil {
 		disklib.EndAccess(params)
 		t.Errorf("Open failed, got error code: %d, error message: %s.", err.VixErrorCode(), err.Error())


### PR DESCRIPTION
Currently, if we run `go mod tidy` in the project home directory. The result will be like below.

```
go: finding module for package github.com/vmware/virtual-disks/pkg/virtual-disks
github.com/vmware/virtual-disks/test tested by
        github.com/vmware/virtual-disks/test.test imports
        github.com/vmware/virtual-disks/pkg/virtual-disks: no matching versions for query "latest"
```

Actually, we should have imported `github.com/vmware/virtual-disks/pkg/virtual_disks` not `github.com/vmware/virtual-disks/pkg/virtual-disks`.