### PR TITLE
Make gvddk log level configurable

### DIFF
--- a/pkg/disklib/gvddk_api.go
+++ b/pkg/disklib/gvddk_api.go
@@ -40,6 +40,18 @@ func Init(majorVersion uint32, minorVersion uint32, dir string) VddkError {
 	return nil
 }
 
+func InitEx(majorVersion uint32, minorVersion uint32, dir string, configFile string) VddkError {
+	libDir := C.CString(dir)
+	defer C.free(unsafe.Pointer(libDir))
+	config := C.CString(configFile)
+	defer C.free(unsafe.Pointer(config))
+	result := C.Init(C.uint32(majorVersion), C.uint32(minorVersion), libDir, config)
+	if result != 0 {
+		return NewVddkError(uint64(result), fmt.Sprintf("Initialize failed. The error code is %d.", result))
+	}
+	return nil
+}
+
 func prepareConnectParams(appGlobal ConnectParams) (*C.VixDiskLibConnectParams, []*C.char) {
 	// Trans string to CString
 	vmxSpec := C.CString(appGlobal.vmxSpec)

--- a/pkg/disklib/gvddk_c.c
+++ b/pkg/disklib/gvddk_c.c
@@ -31,7 +31,13 @@ bool ProgressFunc(void *progressData, int percentCompleted)
 
 VixError Init(uint32 major, uint32 minor, char* libDir)
 {
-    VixError result = VixDiskLib_InitEx(major, minor, NULL, NULL, NULL, libDir, NULL);
+    VixError result = VixDiskLib_Init(major, minor, NULL, NULL, NULL, libDir);
+    return result;
+}
+
+VixError InitEx(uint32 major, uint32 minor, char* libDir, char* configFile)
+{
+    VixError result = VixDiskLib_InitEx(major, minor, NULL, NULL, NULL, libDir, configFile);
     return result;
 }
 

--- a/pkg/disklib/gvddk_c.h
+++ b/pkg/disklib/gvddk_c.h
@@ -31,6 +31,7 @@ typedef struct {
 void LogFunc(const char *fmt, va_list args);
 void GoLogWarn(char * msg);
 VixError Init(uint32 major, uint32 minor, char* libDir);
+VixError InitEx(uint32 major, uint32 minor, char* libDir, char* configFile);
 VixError Connect(VixDiskLibConnectParams *cnxParams, VixDiskLibConnection *connection);
 VixError ConnectEx(VixDiskLibConnectParams *cnxParams, bool readOnly, char* transportModes, VixDiskLibConnection *connection);
 DiskHandle Open(VixDiskLibConnection conn, char* path, uint32 flags);

--- a/test/initex_test.go
+++ b/test/initex_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2018-2021 the Go Library for Virtual Disk Development Kit contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"github.com/vmware/virtual-disks/pkg/disklib"
+	"os"
+	"testing"
+)
+
+func TestInitEx(t *testing.T) {
+	// Set up
+	path := os.Getenv("LIBPATH")
+	if path == "" {
+		t.Skip("Skipping testing if environment variables are not set.")
+	}
+	config := os.Getenv("CONFIGFILE")
+	if config == "" {
+		t.Skip("Skipping testing if environment variables are not set.")
+	}
+	res := disklib.InitEx(7, 0, path, config)
+	if res != nil {
+		t.Errorf("Init failed, got error code: %d, error message: %s.", res.VixErrorCode(), res.Error())
+	}
+	serverName := os.Getenv("IP")
+	thumPrint := os.Getenv("THUMBPRINT")
+	userName := os.Getenv("USERNAME")
+	password := os.Getenv("PASSWORD")
+	fcdId := os.Getenv("FCDID")
+	ds := os.Getenv("DATASTORE")
+	identity := os.Getenv("IDENTITY")
+	params := disklib.NewConnectParams("", serverName,thumPrint, userName,
+		password, fcdId, ds, "", "", identity, "", disklib.VIXDISKLIB_FLAG_OPEN_COMPRESSION_SKIPZ,
+		false, disklib.NBD)
+	err1 := disklib.PrepareForAccess(params)
+	if err1 != nil {
+		t.Errorf("Prepare for access failed. Error code: %d. Error message: %s.", err1.VixErrorCode(), err1.Error())
+	}
+	conn, err2 := disklib.ConnectEx(params)
+	if err2 != nil {
+		disklib.EndAccess(params)
+		t.Errorf("Connect to vixdisk lib failed. Error code: %d. Error message: %s.", err2.VixErrorCode(), err2.Error())
+	}
+	disklib.Disconnect(conn)
+	disklib.EndAccess(params)
+}


### PR DESCRIPTION
Vddk supports user to config log level by passing a configFile and the it will be used when initial. Currenlty in virtual-disks api, we explicitly passing NULL into init function.

This pr includes:
1. Vddk has two init function: VixDiskLib_Init and VixDiskLib_InitEx, VixDiskLib_InitEx support user to pass configfile. Currenlty Init wrapper function eventually calls VixDiskLib_InitEx in C level. Change to call VixDiskLib_Init.
2. Add the wrapper function for VixDiskLib_InitEx in gvddk.

 