### PR TITLE
Fix InitEx bug: change int64 to C.VixError

### DIFF
--- a/pkg/disklib/gvddk_api.go
+++ b/pkg/disklib/gvddk_api.go
@@ -41,7 +41,7 @@ func Init(majorVersion uint32, minorVersion uint32, dir string) VddkError {
 }
 
 func InitEx(majorVersion uint32, minorVersion uint32, dir string, configFile string) VddkError {
-	var result int64
+	var result C.VixError
 	libDir := C.CString(dir)
 	defer C.free(unsafe.Pointer(libDir))
 	if configFile == "" {


### PR DESCRIPTION
Change int64 to C.VixError in InitEx.