### PR TITLE
Add snapshotRef parameter in ConnectEx

### DIFF
--- a/pkg/disklib/gvddk_api.go
+++ b/pkg/disklib/gvddk_api.go
@@ -114,9 +114,11 @@ func ConnectEx(appGlobal ConnectParams) (VixDiskLibConnection, VddkError) {
 	var connection VixDiskLibConnection
 	cnxParams, toFree := prepareConnectParams(appGlobal)
 	defer freeParams(toFree)
+	snapshotRef := C.CString(appGlobal.snapshotRef)
+	defer C.free(unsafe.Pointer(snapshotRef))
 	modes := C.CString(appGlobal.mode)
 	defer C.free(unsafe.Pointer(modes))
-	err := C.ConnectEx(cnxParams, C._Bool(appGlobal.readOnly), modes, &connection.conn)
+	err := C.ConnectEx(cnxParams, C._Bool(appGlobal.readOnly), snapshotRef, modes, &connection.conn)
 	if err != 0 {
 		return VixDiskLibConnection{}, NewVddkError(uint64(err), fmt.Sprintf("ConnectEx failed. The error code is %d.", err))
 	}

--- a/pkg/disklib/gvddk_c.c
+++ b/pkg/disklib/gvddk_c.c
@@ -47,9 +47,9 @@ VixError Connect(VixDiskLibConnectParams *cnxParams, VixDiskLibConnection *conne
     return vixError;
 }
 
-VixError ConnectEx(VixDiskLibConnectParams *cnxParams, bool readOnly, char* transportModes, VixDiskLibConnection *connection) {
+VixError ConnectEx(VixDiskLibConnectParams *cnxParams, bool readOnly, char* snapshotRef, char* transportModes, VixDiskLibConnection *connection) {
     VixError vixError;
-    vixError = VixDiskLib_ConnectEx(cnxParams, readOnly, "", transportModes, connection);
+    vixError = VixDiskLib_ConnectEx(cnxParams, readOnly, snapshotRef, transportModes, connection);
     return vixError;
 }
 

--- a/pkg/disklib/gvddk_c.h
+++ b/pkg/disklib/gvddk_c.h
@@ -33,7 +33,7 @@ void GoLogWarn(char * msg);
 VixError Init(uint32 major, uint32 minor, char* libDir);
 VixError InitEx(uint32 major, uint32 minor, char* libDir, char* configFile);
 VixError Connect(VixDiskLibConnectParams *cnxParams, VixDiskLibConnection *connection);
-VixError ConnectEx(VixDiskLibConnectParams *cnxParams, bool readOnly, char* transportModes, VixDiskLibConnection *connection);
+VixError ConnectEx(VixDiskLibConnectParams *cnxParams, bool readOnly, char* snapshotRef, char* transportModes, VixDiskLibConnection *connection);
 DiskHandle Open(VixDiskLibConnection conn, char* path, uint32 flags);
 VixError PrepareForAccess(VixDiskLibConnectParams *cnxParams, char* identity);
 void Params_helper(VixDiskLibConnectParams *cnxParams, char* arg1, char* arg2, char* arg3, bool isFcd, bool isSession);

--- a/pkg/disklib/gvddk_helper.go
+++ b/pkg/disklib/gvddk_helper.go
@@ -82,20 +82,21 @@ const (
 type VixDiskLibSectorType uint64
 
 type ConnectParams struct {
-	vmxSpec    string
-	serverName string
-	thumbPrint string
-	userName   string
-	password   string
-	fcdId      string
-	ds         string
-	fcdssId    string
-	cookie     string
-	identity   string
-	path       string
-	flag       uint32
-	readOnly   bool
-	mode       string
+	vmxSpec     string
+	serverName  string
+	thumbPrint  string
+	userName    string
+	password    string
+	fcdId       string
+	ds          string
+	fcdssId     string
+	cookie      string
+	identity    string
+	path        string
+	flag        uint32
+	readOnly    bool
+	mode        string
+	snapshotRef string
 }
 
 type VixDiskLibHandle struct {
@@ -172,22 +173,23 @@ func (this vddkErrorImpl) VixErrorCode() uint64 {
 }
 
 func NewConnectParams(vmxSpec string, serverName string, thumbPrint string, userName string, password string,
-	fcdId string, ds string, fcdssId string, cookie string, identity string, path string, flag uint32, readOnly bool, mode string) ConnectParams {
+	fcdId string, ds string, fcdssId string, cookie string, identity string, path string, flag uint32, readOnly bool, mode string, snapshotRef string) ConnectParams {
 	params := ConnectParams{
-		vmxSpec:    vmxSpec,
-		serverName: serverName,
-		thumbPrint: thumbPrint,
-		userName:   userName,
-		password:   password,
-		fcdId:      fcdId,
-		ds:         ds,
-		fcdssId:    fcdssId,
-		cookie:     cookie,
-		identity:   identity,
-		path:       path,
-		flag:       flag,
-		readOnly:   readOnly,
-		mode:       mode,
+		vmxSpec:     vmxSpec,
+		serverName:  serverName,
+		thumbPrint:  thumbPrint,
+		userName:    userName,
+		password:    password,
+		fcdId:       fcdId,
+		ds:          ds,
+		fcdssId:     fcdssId,
+		cookie:      cookie,
+		identity:    identity,
+		path:        path,
+		flag:        flag,
+		readOnly:    readOnly,
+		mode:        mode,
+		snapshotRef: snapshotRef,
 	}
 	return params
 }

--- a/pkg/virtual_disks/gvddk.go
+++ b/pkg/virtual_disks/gvddk.go
@@ -42,7 +42,8 @@ func OpenFCD(serverName string, thumbPrint string, userName string, password str
 		"",
 		flags,
 		readOnly,
-		transportMode)
+		transportMode,
+		"")
 	return Open(globalParams, logger)
 }
 

--- a/test/low_level_test.go
+++ b/test/low_level_test.go
@@ -40,7 +40,7 @@ func TestCreate(t *testing.T) {
 	identity := os.Getenv("IDENTITY")
 	params := disklib.NewConnectParams("", serverName,thumPrint, userName,
 		password, fcdId, ds, "", "", identity, "", disklib.VIXDISKLIB_FLAG_OPEN_COMPRESSION_SKIPZ,
-		false, disklib.NBD)
+		false, disklib.NBD, "")
 	err1 := disklib.PrepareForAccess(params)
 	if err1 != nil {
 		t.Errorf("Prepare for access failed. Error code: %d. Error message: %s.", err1.VixErrorCode(), err1.Error())


### PR DESCRIPTION
Currently in ConnectEx() we hardcoding snapshotRef as empty string, which is not resonable. This pr updates ConnectEx() and adds the snapshotRef parameter.

Fix issue #11 

snapshotRef:
A managed object reference to the snapshot of the virtual machine whose disks will be accessed with this connection. Specifying this property is only meaningful if the vmxSpec property in connectParams is set as well.