### PR TITLE
Partial support for async read and wait

### DIFF
--- a/pkg/disklib/gvddk_api.go
+++ b/pkg/disklib/gvddk_api.go
@@ -396,6 +396,23 @@ func Read(diskHandle VixDiskLibHandle, startSector uint64, numSectors uint64, bu
 	return nil
 }
 
+func ReadAsync(diskHandle VixDiskLibHandle, startSector uint64, numSectors uint64, buf []byte) VddkError {
+	cbuf := ((*C.uint8)(unsafe.Pointer(&buf[0])))
+	res := C.VixDiskLib_ReadAsync(diskHandle.dli, C.VixDiskLibSectorType(startSector), C.VixDiskLibSectorType(numSectors), cbuf, nil, nil)
+	if res != 0 {
+		return NewVddkError(uint64(res), fmt.Sprintf("Read async from virtual disk file failed. The error code is %d.", res))
+	}
+	return nil
+}
+
+func Wait(diskHandle VixDiskLibHandle) VddkError {
+	res := C.VixDiskLib_Wait(diskHandle.dli)
+	if res != 0 {
+		return NewVddkError(uint64(res), fmt.Sprintf("Wait failed. The error code is %d.", res))
+	}
+	return nil
+}
+
 func Write(diskHandle VixDiskLibHandle, startSector uint64, numSectors uint64, buf []byte) VddkError {
 	cbuf := ((*C.uint8)(unsafe.Pointer(&buf[0])))
 	res := C.VixDiskLib_Write(diskHandle.dli, C.VixDiskLibSectorType(startSector), C.VixDiskLibSectorType(numSectors), cbuf)


### PR DESCRIPTION
While a full integration of the async api may prove challenging due to garbage collection issues with pointers across the CGO boundary, this minimal support for readAsync and Wait without callbacks covers the most common use case and is relatively safe and straightforward. The caller would just need to maintain a reference to the slices passed into the readAsync calls so they don't get garbage collected, and also ensure that slices used in concurrent read calls do not overlap, but hopefully these are both intuitive.
 
I've also elected to fallback on the synchronous case when the async read calls are not aligned to sectors, since this is a complicated and uncommon edge case. 