### PR TITLE
Prevent panic when QueryAllocatedBlocks result empty

### DIFF
--- a/pkg/disklib/gvddk_api.go
+++ b/pkg/disklib/gvddk_api.go
@@ -446,7 +446,12 @@ func QueryAllocatedBlocks(diskHandle VixDiskLibHandle, startSector VixDiskLibSec
 	}
 
 	retList := make([]VixDiskLibBlock, bld.numBlocks)
-	C.BlockListCopyAndFree(&bld, (*C.VixDiskLibBlock)(unsafe.Pointer(&retList[0])))
+
+	if bld.numBlocks > 0 {
+		C.BlockListCopyAndFree(&bld, (*C.VixDiskLibBlock)(unsafe.Pointer(&retList[0])))
+	} else {
+		C.VixDiskLib_FreeBlockList((*C.VixDiskLibBlockList)(bld.blockList))
+	}
 
 	return retList, nil
 }


### PR DESCRIPTION
Handle properly empty result from C.QueryAllocatedBlocks call in QueryAllocatedBlocks